### PR TITLE
Include pdf and epub in docs build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -22,3 +22,7 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+
+formats:
+  - pdf
+  - epub


### PR DESCRIPTION
Like was done in ScopeSim recently. Mostly to try this with the "book theme" used here.