### PR TITLE
Call bump workflow in devops to avoid copies

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -43,52 +43,9 @@ on:
 jobs:
   bump:
     name: Bump version number
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    outputs:
-      bumpmsg: ${{ steps.bumping.outputs.BUMP_MSG }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.branch }}
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
-      - name: Set up Poetry
-        uses: abatilo/actions-poetry@v2
-        with:
-          poetry-version: "1.7.1"
-
-      - name: Bump package Version using Poetry
-        id: bumping
-        env:
-          RULE: ${{ inputs.rule }}
-          DRY: ${{ inputs.dry-run && '--dry-run' || '' }}
-        run: echo "BUMP_MSG=$(poetry version $DRY $RULE)" >> $GITHUB_OUTPUT
-
-      - name: Output debug msg
-        if: inputs.dry-run
-        env:
-          BUMP_MSG: ${{ steps.bumping.outputs.BUMP_MSG }}
-        run: |
-          echo "## $BUMP_MSG" >> $GITHUB_STEP_SUMMARY
-          echo "Dry run only, no actual modification made." >> $GITHUB_STEP_SUMMARY
-
-      - name: Commit changes
-        # could also use https://github.com/stefanzweifel/git-auto-commit-action instead
-        if: ${{ ! inputs.dry-run }}
-        env:
-          BUMP_MSG: ${{ steps.bumping.outputs.BUMP_MSG }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -am "$BUMP_MSG"
-          git push
-          echo "## $BUMP_MSG" >> $GITHUB_STEP_SUMMARY
-          echo "Successfully committed and pushed version bump." >> $GITHUB_STEP_SUMMARY
+    uses: AstarVienna/DevOps/.github/workflows/bump.yml@main
+    secrets: inherit
+    with:
+      dry-run: ${{ inputs.dry-run }}
+      rule: ${{ inputs.rule }}
+      branch: ${{ inputs.branch }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -20,32 +20,10 @@ on:
         - prerelease
         - "prerelease --next-phase"
 
-  workflow_call:
-    inputs:
-      dry-run:
-        type: boolean
-        description: Only output new version number, no actual change.
-        required: false
-      rule:
-        type: string
-        description: Version bump level
-        required: true
-      branch:
-        type: string
-        description: Branch (ref) to checkout and push changes to
-        required: false
-        default: ${{ github.ref_name }}
-    outputs:
-      bumpmsg:
-        description: Message created by the version bump.
-        value: ${{ jobs.bump.outputs.bumpmsg }}
-
 jobs:
   bump:
-    name: Bump version number
     uses: AstarVienna/DevOps/.github/workflows/bump.yml@main
     secrets: inherit
     with:
       dry-run: ${{ inputs.dry-run }}
       rule: ${{ inputs.rule }}
-      branch: ${{ inputs.branch }}

--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -21,7 +21,7 @@ on:
         - "prerelease --next-phase"
 
 jobs:
-  bump:
+  Bump:
     uses: AstarVienna/DevOps/.github/workflows/bump.yml@main
     secrets: inherit
     with:

--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -5,7 +5,7 @@ on:
       - published
 
 jobs:
-  build:
+  Build:
     name: Build package using Poetry
     runs-on: ubuntu-latest
     steps:
@@ -44,7 +44,7 @@ jobs:
         if: ${{ success() }}
         run: echo "### Successfully built package" >> $GITHUB_STEP_SUMMARY
 
-  publish:
+  Publish:
     name: Publish package to PyPI
     runs-on: ubuntu-latest
     needs: build
@@ -77,11 +77,11 @@ jobs:
           POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
         run: poetry publish >> $GITHUB_STEP_SUMMARY
 
-  bump:
+  Bump:
     name: Bump to (next) dev version
     needs: publish
     if: ${{ needs.publish.result == 'success' }}
-    uses: ./.github/workflows/bump.yml
+    uses: AstarVienna/DevOps/.github/workflows/bump.yml@main
     secrets: inherit
     with:
       rule: prerelease

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "speXtra"
-version = "0.41.0a0"
+version = "0.41.0a1"
 description = "Tool to manage and manipulate astronomical spectra."
 license = "MIT"
 authors = ["Miguel Verdugo <mverduol@gmail.com>"]


### PR DESCRIPTION
This is especially useful if versions need to be updated, which currently has to be done in every repo manually for bump and publish workflows...