### PR TITLE
Allow dashes in filter names

### DIFF
--- a/spextra/containers.py
+++ b/spextra/containers.py
@@ -12,7 +12,7 @@ from .libraries import Library, SpecLibrary, FilterSystem, ExtCurvesLibrary
 
 __all__ = ["SpectrumContainer", "ExtCurveContainer", "FilterContainer"]
 
-NAME_REGEX = re.compile(r"^(?P<libname>\w+(/\w+)*)/(?P<basename>[\w\.]+)$")
+NAME_REGEX = re.compile(r"^(?P<libname>\w+(/\w+)*)/(?P<basename>[\w\.\-]+)$")
 
 
 class DBFile:

--- a/spextra/tests/test_spextra.py
+++ b/spextra/tests/test_spextra.py
@@ -51,6 +51,14 @@ class TestPassbandInstances:
         passband = Passband("elt/micado/Y")
         assert isinstance(passband, SpectralElement)
 
+    def test_database_dash(self):
+        passband = Passband("elt/micado/I-long")
+        assert isinstance(passband, SpectralElement)
+
+    def test_database_underscore(self):
+        passband = Passband("elt/micado/H2_1-0S1")
+        assert isinstance(passband, SpectralElement)
+
     @pytest.mark.usefixtures("mock_dir")
     def test_filename(self, mock_dir):
         passband = Passband.from_file(filename=mock_dir / "Y.dat")


### PR DESCRIPTION
From slack:

> https://spextra.readthedocs.io/en/latest/filters.html#etc In this page, each filter name with '-' does not work like 'I-long' or 'Br-gamma' etc.

The `NAME_REGEX` introduced in #10 did not allow dashes in the filter names and these were not tested.