### PR TITLE
Fix waves check

### DIFF
--- a/spextra/spextra.py
+++ b/spextra/spextra.py
@@ -443,7 +443,9 @@ class Spextrum(SourceSpectrum, SpectrumContainer):
         spex : Spextrum
             New ``Spextrum`` instance.
         """
-        waves = (waves or _default_waves()).to(u.AA).value
+        if waves is None:
+            waves = _default_waves()
+        waves = waves.to(u.AA).value
 
         # The if-statement below also allowed amplitude.unit to be
         # u.Unit("vegamag"). Vegamag is removed from astropy, so the
@@ -509,7 +511,9 @@ class Spextrum(SourceSpectrum, SpectrumContainer):
         -------
         a scaled black-body spectrum
         """
-        waves = (waves or _default_waves()).to(u.AA)
+        if waves is None:
+            waves = _default_waves()
+        waves = waves.to(u.AA)
         blackbody = BlackBody1D(temperature=temperature.to(u.K).value)
 
         spex = cls(modelclass=Empirical1D, points=waves,
@@ -558,7 +562,9 @@ class Spextrum(SourceSpectrum, SpectrumContainer):
         spex : Spextrum
             New ``Spextrum`` instance.
         """
-        waves = (waves or _default_waves()).to(u.AA)
+        if waves is None:
+            waves = _default_waves()
+        waves = waves.to(u.AA)
         power = SourceSpectrum(
             PowerLawFlux1D, amplitude=1, x_0=x_0, alpha=alpha)
         spex = cls(modelclass=Empirical1D, points=waves,

--- a/spextra/tests/test_spextra.py
+++ b/spextra/tests/test_spextra.py
@@ -96,8 +96,12 @@ class TestSpextrumInstances:
         assert isinstance(sp2, Spextrum)
 
     @pytest.mark.parametrize("unit", [u.mag, u.STmag, u.ABmag])
-    def test_flat_spectrum(self, unit):
-        sp = Spextrum.flat_spectrum(amplitude=10*unit)
+    @pytest.mark.parametrize("waves", [np.arange(1e4, 2.7e4, 100) * u.AA, None])
+    def test_flat_spectrum(self, unit, waves):
+        sp = Spextrum.flat_spectrum(
+            waves=waves,
+            amplitude=10*unit,
+        )
         assert isinstance(sp, Spextrum)
 
     def test_mul_with_scalar(self, spec):
@@ -128,6 +132,40 @@ class TestSpextrumInstances:
     @pytest.mark.webtest
     def test_black_body_spectrum(self, bb_spec):
         assert isinstance(bb_spec, Spextrum)
+
+    @pytest.mark.webtest
+    def test_black_body_spectrum_units(self):
+        bb = Spextrum.black_body_spectrum(
+                temperature=9500 * u.K,
+                amplitude=0*u.ABmag,
+                filter_curve="V",
+                waves=np.arange(3e3, 8e3, 100)*u.AA,
+        )
+        assert isinstance(bb, Spextrum)
+        bb = Spextrum.black_body_spectrum(
+                temperature=9500*u.K,
+                amplitude=0*u.ABmag,
+                filter_curve="V",
+                waves=None,
+        )
+        assert isinstance(bb, Spextrum)
+
+    @pytest.mark.webtest
+    def test_powerlaw_units(self):
+        spec = Spextrum.powerlaw(
+                x_0=9500*u.AA,
+                amplitude=0*u.ABmag,
+                filter_curve="V",
+                waves=np.arange(3e3, 8e3, 100)*u.AA,
+        )
+        assert isinstance(spec, Spextrum)
+        spec = Spextrum.powerlaw(
+                x_0=9500*u.AA,
+                amplitude=0*u.ABmag,
+                filter_curve="V",
+                waves=None,
+        )
+        assert isinstance(spec, Spextrum)
 
     @pytest.mark.webtest
     def test_photons_in_range(self, bb_spec):


### PR DESCRIPTION
This is broken, because waves is a Quantity, and "Quantity truthiness is ambiguous, especially for logarithmic units and temperatures. Use explicit comparisons". In particular, the example in https://github.com/AstarVienna/ScopeSim_Templates/blob/main/scopesim_templates/calibration/calibration.py#L44 raises the quoted ValueError. Fixes https://github.com/AstarVienna/speXtra/pull/43/files#r1819593457