### PR TITLE
Ignore our own DeprecationWarnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,10 @@ filterwarnings = [
 
     # Should probably be fixed:
     "default:unclosed file <_io.BufferedReader name=:ResourceWarning",
+
+    # Internal deprecation warning; the function should be tested as long
+    # as it is in the codebase.
+    "default:The download_file function is deprecated and will be removed in v1.0. Please use retriever.fetch instead.:DeprecationWarning"
 ]
 
 [tool.coverage.report]


### PR DESCRIPTION
I'll just merge this to get https://github.com/AstarVienna/ScopeSim_Data/pull/20 working.

This wasn't checked earlier because locally I had the files cached, and the webtests do not run on the CI.

The deprecated functionality should be tested as long as it is in the codebase, so ignoring it is fine.

However, we are actually actively using the deprecated functionality, which is a bit weird.

