### PR TITLE
Initialize self.repr to aid debugging

### DIFF
--- a/spextra/spextra.py
+++ b/spextra/spextra.py
@@ -312,6 +312,7 @@ class Spextrum(SourceSpectrum, SpectrumContainer):
     DEFAULT_SPECTRA = DEFAULT_DATA.spectra
 
     def __init__(self, template_name=None, modelclass=None, **kwargs):
+        self.repr = "Uninitialized"
         if template_name is not None:
             self.from_template_name(template_name, **kwargs)
         elif modelclass is not None:


### PR DESCRIPTION
`self.repr` needs to be set when debugging the `__init__()` methods.

speXtra abuses `__repr__()` though. That should all be `__str__()`.