### PR TITLE
Add dummy line break to markdown_link_check.yml

### DIFF
--- a/.github/workflows/markdown_link_check.yml
+++ b/.github/workflows/markdown_link_check.yml
@@ -18,3 +18,4 @@ on:
 jobs:
   markdown-link-check:
     uses: AstarVienna/DevOps/.github/workflows/markdown_link_check.yml@main
+


### PR DESCRIPTION
Github complains that

Check failure on line 20 in .github/workflows/markdown_link_check.yml GitHub Actions / .github/workflows/markdown_link_check.yml

Invalid workflow file

error parsing called workflow
".github/workflows/markdown_link_check.yml"
-> "AstarVienna/DevOps/.github/workflows/markdown_link_check.yml@main" (source branch with sha:4211c4cccda99f657f3691fe2f0212ef5dc93b0a) : (Line: 7, Col: 6): Unexpected value ''

But the workflow file is bit-wise identical to the one in ScopeSim and that one is fine...