### PR TITLE
Turn `DeprecationWarning`s into `FutureWarning`s, specify version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,14 +79,14 @@ filterwarnings = [
     # Should certainly be fixed:
 
     # https://github.com/AstarVienna/speXtra/issues/61
-    "ignore:The 'name plus file extension' property*:PendingDeprecationWarning",
+    "ignore:The 'name plus file extension' property*:FutureWarning",
 
     # Should probably be fixed:
     "default:unclosed file <_io.BufferedReader name=:ResourceWarning",
 
     # Internal deprecation warning; the function should be tested as long
     # as it is in the codebase.
-    "default:The download_file function is deprecated and will be removed in v1.0. Please use retriever.fetch instead.:DeprecationWarning"
+    "ignore:The download_file function is deprecated and will be removed in v1.0. Please use retriever.fetch instead.:FutureWarning"
 ]
 
 [tool.coverage.report]

--- a/spextra/containers.py
+++ b/spextra/containers.py
@@ -45,9 +45,9 @@ class DBFile:
     def datafile(self):
         """Name and extension of the file."""
         warnings.warn("The 'name plus file extension' property will be moved "
-                      "to .filename in the next minor pre-release, making "
+                      "to .filename in version 0.44.0, making "
                       ".datafile deprecated.",
-                      PendingDeprecationWarning, 2)
+                      FutureWarning, 2)
         return self.basename + self.library.file_extension
 
     @property
@@ -62,19 +62,19 @@ class DBFile:
     def filename(self):
         """Deprecated feature."""
         warnings.warn("The .filename property is deprecated and will refer to "
-                      "the full name incl. file extension in future versions. "
+                      "the full name incl. file extension in version 0.44.0. "
                       "For the absolute file path, please use .path instead!",
-                      DeprecationWarning, 2)
+                      FutureWarning, 2)
         return self.path
 
     @property
     def name(self):
         """Deprecated feature."""
         warnings.warn("Accessing the library name directly via the .name "
-                      "property is ambiguous. In future versions, .name will "
+                      "property is ambiguous. From v0.44.0 onwards, .name will "
                       "refer to the .basename attribute + library_name. "
                       "Please use the more explicit .library.name instead!",
-                      DeprecationWarning, 2)
+                      FutureWarning, 2)
         return self.library.name
 
     @property
@@ -97,8 +97,8 @@ class DBFile:
         if not key.startswith("__") and hasattr(self.library, key):
             warnings.warn(f"Accessing library attributes like '{key}' "
                           "directly is deprecated and will raise an error in "
-                          "future versions. Please use the more explicit "
-                          f".library.{key} instead!", DeprecationWarning, 2)
+                          "version 0.44.0. Please use the more explicit "
+                          f".library.{key} instead!", FutureWarning, 2)
         return getattr(self.library, key)
 
 
@@ -118,7 +118,7 @@ class SpectrumContainer(DBFile):
         """Deprecated feature."""
         warnings.warn("The .template_name property is deprecated and will be "
                       "removed in v1.0. Please use the identical .basename "
-                      "instead!", DeprecationWarning, 2)
+                      "instead!", FutureWarning, 2)
         return self.basename
 
     @property
@@ -126,7 +126,7 @@ class SpectrumContainer(DBFile):
         """Deprecated feature."""
         warnings.warn("The .template_comment property is deprecated and will be "
                       "removed in v1.0. Please use the identical .description "
-                      "instead!", DeprecationWarning, 2)
+                      "instead!", FutureWarning, 2)
         return self.description
 
 
@@ -146,7 +146,7 @@ class FilterContainer(DBFile):
         """Deprecated feature."""
         warnings.warn("The .filter_comment property is deprecated and will be "
                       "removed in v1.0. Please use the identical .description "
-                      "instead!", DeprecationWarning, 2)
+                      "instead!", FutureWarning, 2)
         return self.description
 
 
@@ -166,5 +166,5 @@ class ExtCurveContainer(DBFile):
         """Deprecated feature."""
         warnings.warn("The .curve_comment property is deprecated and will be "
                       "removed in v1.0. Please use the identical .description "
-                      "instead!", DeprecationWarning, 2)
+                      "instead!", FutureWarning, 2)
         return self.description

--- a/spextra/downloads.py
+++ b/spextra/downloads.py
@@ -24,7 +24,7 @@ def download_file(remote_url, local_name):
     """For backwards compatibility only."""
     warnings.warn("The download_file function is deprecated and will be "
                   "removed in v1.0. Please use retriever.fetch instead.",
-                  DeprecationWarning, stacklevel=2)
+                  FutureWarning, stacklevel=2)
     file = pooch.retrieve(remote_url, known_hash=None,
                           fname=local_name.name, path=local_name.parent)
     return file

--- a/spextra/libraries.py
+++ b/spextra/libraries.py
@@ -149,7 +149,7 @@ class SpecLibrary(Library):
             warnings.warn("Constructing using the 'library_name' argument is "
                           "deprecated and will raise an error in v1.0. Please "
                           "use the more general 'name' argument.",
-                          DeprecationWarning, 2)
+                          FutureWarning, 2)
             name = library_name
         if name is None and library_name is None:
             raise ConstructorError("name must be passed to constructor")
@@ -161,7 +161,7 @@ class SpecLibrary(Library):
         """Deprecated feature."""
         warnings.warn("The alias .library_name is deprecated and will be "
                       "removed in v1.0. Please use .name instead!",
-                      DeprecationWarning, 2)
+                      FutureWarning, 2)
         return self.name
 
     @property
@@ -169,7 +169,7 @@ class SpecLibrary(Library):
         """Deprecated feature."""
         warnings.warn("The alias .templates is deprecated and will be "
                       "removed in v1.0. Please use .items() instead!",
-                      DeprecationWarning, 2)
+                      FutureWarning, 2)
         return list(self.items())
 
     @property
@@ -177,14 +177,14 @@ class SpecLibrary(Library):
         """Deprecated feature."""
         warnings.warn("The alias .template_names is deprecated and will be "
                       "removed in v1.0. Please use the  more general "
-                      ".keys() instead!", DeprecationWarning, 2)
+                      ".keys() instead!", FutureWarning, 2)
         return list(self.keys())
 
     @property
     def template_comments(self):
         """Deprecated feature."""
         warnings.warn("The properts .template_comments is deprecated and will "
-                      "be removed in v1.0.", DeprecationWarning, 2)
+                      "be removed in v1.0.", FutureWarning, 2)
         return list(self.values())
 
     def __str__(self) -> str:
@@ -212,7 +212,7 @@ class FilterSystem(Library):
             warnings.warn("Constructing using the 'filter_system' argument is "
                           "deprecated and will raise an error in v1.0. Please "
                           "use the more general 'name' argument.",
-                          DeprecationWarning, 2)
+                          FutureWarning, 2)
             name = filter_system
         if name is None and filter_system is None:
             raise ConstructorError("name must be passed to constructor")
@@ -224,7 +224,7 @@ class FilterSystem(Library):
         """Deprecated feature."""
         warnings.warn("The alias .filter_system is deprecated and will be "
                       "removed in v1.0. Please use .name instead!",
-                      DeprecationWarning, 2)
+                      FutureWarning, 2)
         return self.name
 
     @property
@@ -232,7 +232,7 @@ class FilterSystem(Library):
         """Deprecated feature."""
         warnings.warn("The alias .filters is deprecated and will be "
                       "removed in v1.0. Please use .items() instead!",
-                      DeprecationWarning, 2)
+                      FutureWarning, 2)
         return list(self.items())
 
     @property
@@ -240,14 +240,14 @@ class FilterSystem(Library):
         """Deprecated feature."""
         warnings.warn("The alias .filter_names is deprecated and will be "
                       "removed in v1.0. Please use the  more general "
-                      ".keys() instead!", DeprecationWarning, 2)
+                      ".keys() instead!", FutureWarning, 2)
         return list(self.keys())
 
     @property
     def filter_comments(self):
         """Deprecated feature."""
         warnings.warn("The properts .filter_comments is deprecated and will "
-                      "be removed in v1.0.", DeprecationWarning, 2)
+                      "be removed in v1.0.", FutureWarning, 2)
         return list(self.values())
 
     def __str__(self) -> str:
@@ -275,7 +275,7 @@ class ExtCurvesLibrary(Library):
             warnings.warn("Constructing using the 'curve_library' argument is "
                           "deprecated and will raise an error in v1.0. Please "
                           "use the more general 'name' argument.",
-                          DeprecationWarning, 2)
+                          FutureWarning, 2)
             name = curve_library
         if name is None and curve_library is None:
             raise ConstructorError("name must be passed to constructor")
@@ -287,7 +287,7 @@ class ExtCurvesLibrary(Library):
         """Deprecated feature."""
         warnings.warn("The alias .curves is deprecated and will be "
                       "removed in v1.0. Please use .items() instead!",
-                      DeprecationWarning, 2)
+                      FutureWarning, 2)
         return list(self.items())
 
     @property
@@ -295,14 +295,14 @@ class ExtCurvesLibrary(Library):
         """Deprecated feature."""
         warnings.warn("The alias .curve_names is deprecated and will be "
                       "removed in v1.0. Please use the  more general "
-                      ".keys() instead!", DeprecationWarning, 2)
+                      ".keys() instead!", FutureWarning, 2)
         return list(self.keys())
 
     @property
     def curve_comments(self):
         """Deprecated feature."""
         warnings.warn("The properts .curve_comments is deprecated and will be "
-                      "removed in v1.0.", DeprecationWarning, 2)
+                      "removed in v1.0.", FutureWarning, 2)
         return list(self.values())
 
     def __str__(self) -> str:

--- a/spextra/spextra.py
+++ b/spextra/spextra.py
@@ -593,8 +593,8 @@ class Spextrum(SourceSpectrum, SpectrumContainer):
     def emission_line_spectra(cls, *args, **kwargs):
         warnings.warn(
             "The 'emission_line_spectra' constructor is deprecated and will be"
-            " removed in a future version. Please use the identical "
-            "'emission_line_spectrum' instead.", DeprecationWarning,
+            " removed in version 0.44.0. Please use the identical "
+            "'emission_line_spectrum' instead.", FutureWarning,
             stacklevel=2)
         return cls.emission_line_spectrum(*args, **kwargs)
 


### PR DESCRIPTION
As discussed elsewhere, `FutureWarning` ususally gets more visibility for the end user than `DeprecationWarning`. The version now speficied is still another minor release away. I left the ones in place that already somewhat optimistically were talking about a v1.0.