### PR TITLE
Run webtests on PRs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,6 @@ jobs:
     secrets: inherit
 
   call-webtests:
-    if: ${{github.event_name == 'workflow_dispatch'}}
     name: Network tests
     uses: AstarVienna/DevOps/.github/workflows/webtests.yml@main
     secrets: inherit


### PR DESCRIPTION
No idea why this was disabled in the first place. It shouldn't be. Also affects coverage, which should now be better.